### PR TITLE
Potential fix for code scanning alert no. 7: URL redirection from remote source

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1826,7 +1826,7 @@ def user_post_save(sender, instance, created, **kwargs):
         instance.save()
 
 
-def is_safe_url(url):
+def is_safe_url(url, allowed_hosts):
     try:
         # available in django 3+
         from django.utils.http import url_has_allowed_host_and_scheme
@@ -1834,7 +1834,7 @@ def is_safe_url(url):
         # django < 3
         from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
 
-    return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
+    return url_has_allowed_host_and_scheme(url, allowed_hosts=allowed_hosts)
 
 
 def get_return_url(request):
@@ -1858,9 +1858,11 @@ def redirect_to_return_url_or_else(request, or_else):
     return redirect(request, request.get_full_path())
 
 
+ALLOWED_HOSTS = ['example.com', 'another-allowed-host.com']  # Define allowed hosts
+
 def redirect(request, redirect_to):
     """Only allow redirects to allowed_hosts to prevent open redirects"""
-    if is_safe_url(redirect_to):
+    if is_safe_url(redirect_to, ALLOWED_HOSTS):
         return HttpResponseRedirect(redirect_to)
     msg = "invalid redirect, host and scheme not in allowed_hosts"
     raise ValueError(msg)


### PR DESCRIPTION
Potential fix for [https://github.com/kblcka/MyPrj4dp/security/code-scanning/7](https://github.com/kblcka/MyPrj4dp/security/code-scanning/7)

To fix the problem, we need to ensure that the `redirect_to` URL is validated against a list of allowed hosts or ensure it does not contain an explicit host name. We can use Django's `url_has_allowed_host_and_scheme` function with a specified list of allowed hosts to achieve this.

1. Update the `is_safe_url` function to accept an `allowed_hosts` parameter and pass it to `url_has_allowed_host_and_scheme`.
2. Modify the `redirect` function to use a predefined list of allowed hosts when calling `is_safe_url`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
